### PR TITLE
Remove CNAME so GitHub Pages works at default domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-liamsalter.com


### PR DESCRIPTION
## Summary
- remove the CNAME file

Removing the CNAME file allows the page to be served at `liamsalter11.github.io` instead of forcing the custom domain.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6857881f24508328983df39650a90902